### PR TITLE
This commit will fix the license url in readme file

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -4,7 +4,7 @@
 
 Copyright (c) 2025
 
-This report (source contained in the [`DSCI-532_2025_15_RetailPulse` repository](https://github.com/UBC-MDS/DSCI-532_2025_15_RetailPulse)) is made available under the **Attribution-NonCommercial-ShareAlike 4.0 International** ([CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/)). 
+This report (source contained in the [`DSCI-532_2025_15_RetailPulse repository`](https://github.com/UBC-MDS/DSCI-532_2025_15_RetailPulse)) is made available under the **Attribution-NonCommercial-ShareAlike 4.0 International** ([CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/)). 
 
 This is a human-readable summary of (and not a substitute for) the [license](https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode).
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The dashboard is built using **Python, Dash, and Plotly**, ensuring an **intuiti
 
 
 ## **License**
-The **RetailPulse software code** contained in this project is licensed under the **MIT License**. See the [LICENSE](https://github.com/UBC-MDS/DSCI-532_2025_15_RetailPulse/blob/main/LICENSE) file for more details.
+The **RetailPulse software code** contained in this project is licensed under the **MIT License**. See the [LICENSE](https://github.com/UBC-MDS/DSCI-532_2025_15_RetailPulse/blob/main/LICENSE.md) file for more details.
 
 The **project report** is licensed under the **Attribution-NonCommercial-ShareAlike 4.0 International (CC BY-NC-SA 4.0)** License. See the license file for details. If reusing any part of this code or report, please provide proper attribution by linking to this repository.
 


### PR DESCRIPTION
The license URL was not working in the readme file because it was simple text file and not md file.