### PR TITLE
revenue-by-product chart + altair conversion + card standardization 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+*__pycache__

--- a/data/explore.ipynb
+++ b/data/explore.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -43,7 +43,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -68,7 +68,7 @@
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
        "      <th>Country</th>\n",
-       "      <th>TotalSales</th>\n",
+       "      <th>Revenue</th>\n",
        "      <th>Quantity</th>\n",
        "      <th>iso_alpha</th>\n",
        "    </tr>\n",
@@ -114,15 +114,15 @@
        "</div>"
       ],
       "text/plain": [
-       "     Country  TotalSales  Quantity iso_alpha\n",
-       "0  Australia   137077.27     83653       AUS\n",
-       "1    Austria    10154.32      4827       AUT\n",
-       "2    Bahrain      548.40       260       BHR\n",
-       "3    Belgium    40910.96     23152       BEL\n",
-       "4     Brazil     1143.60       356       BRA"
+       "     Country    Revenue  Quantity iso_alpha\n",
+       "0  Australia  137077.27     83653       AUS\n",
+       "1    Austria   10154.32      4827       AUT\n",
+       "2    Bahrain     548.40       260       BHR\n",
+       "3    Belgium   40910.96     23152       BEL\n",
+       "4     Brazil    1143.60       356       BRA"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -152,17 +152,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/var/folders/2j/ryb6v7ns2t9760z6yvvtp83m0000gn/T/ipykernel_40201/3577123508.py:3: FutureWarning: 'M' is deprecated and will be removed in a future version, please use 'ME' instead.\n",
-      "  time_series = df.resample('M', on='InvoiceDate').agg({'TotalSales': 'sum'}).reset_index()\n"
-     ]
-    },
     {
      "data": {
       "text/html": [
@@ -185,7 +177,7 @@
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
        "      <th>InvoiceDate</th>\n",
-       "      <th>TotalSales</th>\n",
+       "      <th>Revenue</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -219,7 +211,7 @@
        "</div>"
       ],
       "text/plain": [
-       "  InvoiceDate  TotalSales\n",
+       "  InvoiceDate     Revenue\n",
        "0  2010-12-31  748957.020\n",
        "1  2011-01-31  560000.260\n",
        "2  2011-02-28  498062.650\n",
@@ -227,7 +219,7 @@
        "4  2011-04-30  493207.121"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -250,439 +242,1013 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>InvoiceNo</th>\n",
-       "      <th>StockCode</th>\n",
-       "      <th>Description</th>\n",
-       "      <th>Quantity</th>\n",
-       "      <th>InvoiceDate</th>\n",
-       "      <th>UnitPrice</th>\n",
-       "      <th>CustomerID</th>\n",
-       "      <th>Country</th>\n",
-       "      <th>TotalSales</th>\n",
-       "      <th>Month</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>220572</th>\n",
-       "      <td>556201</td>\n",
-       "      <td>23084</td>\n",
-       "      <td>RABBIT NIGHT LIGHT</td>\n",
-       "      <td>12</td>\n",
-       "      <td>2011-06-09 13:01:00</td>\n",
-       "      <td>2.08</td>\n",
-       "      <td>12347.0</td>\n",
-       "      <td>Iceland</td>\n",
-       "      <td>24.96</td>\n",
-       "      <td>2011-06</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>220573</th>\n",
-       "      <td>556201</td>\n",
-       "      <td>23162</td>\n",
-       "      <td>REGENCY TEA STRAINER</td>\n",
-       "      <td>8</td>\n",
-       "      <td>2011-06-09 13:01:00</td>\n",
-       "      <td>3.75</td>\n",
-       "      <td>12347.0</td>\n",
-       "      <td>Iceland</td>\n",
-       "      <td>30.00</td>\n",
-       "      <td>2011-06</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>220574</th>\n",
-       "      <td>556201</td>\n",
-       "      <td>23171</td>\n",
-       "      <td>REGENCY TEA PLATE GREEN</td>\n",
-       "      <td>12</td>\n",
-       "      <td>2011-06-09 13:01:00</td>\n",
-       "      <td>1.65</td>\n",
-       "      <td>12347.0</td>\n",
-       "      <td>Iceland</td>\n",
-       "      <td>19.80</td>\n",
-       "      <td>2011-06</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>220575</th>\n",
-       "      <td>556201</td>\n",
-       "      <td>23172</td>\n",
-       "      <td>REGENCY TEA PLATE PINK</td>\n",
-       "      <td>12</td>\n",
-       "      <td>2011-06-09 13:01:00</td>\n",
-       "      <td>1.65</td>\n",
-       "      <td>12347.0</td>\n",
-       "      <td>Iceland</td>\n",
-       "      <td>19.80</td>\n",
-       "      <td>2011-06</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>220576</th>\n",
-       "      <td>556201</td>\n",
-       "      <td>23170</td>\n",
-       "      <td>REGENCY TEA PLATE ROSES</td>\n",
-       "      <td>12</td>\n",
-       "      <td>2011-06-09 13:01:00</td>\n",
-       "      <td>1.65</td>\n",
-       "      <td>12347.0</td>\n",
-       "      <td>Iceland</td>\n",
-       "      <td>19.80</td>\n",
-       "      <td>2011-06</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "       InvoiceNo StockCode               Description  Quantity  \\\n",
-       "220572    556201     23084        RABBIT NIGHT LIGHT        12   \n",
-       "220573    556201     23162      REGENCY TEA STRAINER         8   \n",
-       "220574    556201     23171  REGENCY TEA PLATE GREEN         12   \n",
-       "220575    556201     23172    REGENCY TEA PLATE PINK        12   \n",
-       "220576    556201     23170  REGENCY TEA PLATE ROSES         12   \n",
-       "\n",
-       "               InvoiceDate  UnitPrice  CustomerID  Country  TotalSales  \\\n",
-       "220572 2011-06-09 13:01:00       2.08     12347.0  Iceland       24.96   \n",
-       "220573 2011-06-09 13:01:00       3.75     12347.0  Iceland       30.00   \n",
-       "220574 2011-06-09 13:01:00       1.65     12347.0  Iceland       19.80   \n",
-       "220575 2011-06-09 13:01:00       1.65     12347.0  Iceland       19.80   \n",
-       "220576 2011-06-09 13:01:00       1.65     12347.0  Iceland       19.80   \n",
-       "\n",
-       "          Month  \n",
-       "220572  2011-06  \n",
-       "220573  2011-06  \n",
-       "220574  2011-06  \n",
-       "220575  2011-06  \n",
-       "220576  2011-06  "
-      ]
-     },
-     "execution_count": 18,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "\n",
     "\n",
-    "df_last_6_months = df[df['InvoiceDate'] >= six_months_ago].copy()\n",
-    "df_last_6_months['Month'] = df_last_6_months['InvoiceDate'].dt.to_period('M')\n",
-    "df_last_6_months.head()"
+    "# df_last_6_months = df[df['InvoiceDate'] >= six_months_ago].copy()\n",
+    "# df_last_6_months['Month'] = df_last_6_months['InvoiceDate'].dt.to_period('M')\n",
+    "# df_last_6_months.head()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 8,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>CustomerID</th>\n",
-       "      <th>Month</th>\n",
-       "      <th>Purchases</th>\n",
-       "      <th>PreviousMonth</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>12347.0</td>\n",
-       "      <td>2011-06</td>\n",
-       "      <td>18</td>\n",
-       "      <td>2011-05</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>12347.0</td>\n",
-       "      <td>2011-08</td>\n",
-       "      <td>22</td>\n",
-       "      <td>2011-07</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>12347.0</td>\n",
-       "      <td>2011-10</td>\n",
-       "      <td>47</td>\n",
-       "      <td>2011-09</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>12347.0</td>\n",
-       "      <td>2011-12</td>\n",
-       "      <td>11</td>\n",
-       "      <td>2011-11</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>12348.0</td>\n",
-       "      <td>2011-09</td>\n",
-       "      <td>3</td>\n",
-       "      <td>2011-08</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "   CustomerID    Month  Purchases PreviousMonth\n",
-       "0     12347.0  2011-06         18       2011-05\n",
-       "1     12347.0  2011-08         22       2011-07\n",
-       "2     12347.0  2011-10         47       2011-09\n",
-       "3     12347.0  2011-12         11       2011-11\n",
-       "4     12348.0  2011-09          3       2011-08"
-      ]
-     },
-     "execution_count": 19,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "customer_months = df_last_6_months.groupby(['CustomerID', 'Month']).size().reset_index(name='Purchases')\n",
-    "customer_months['PreviousMonth'] = customer_months['Month'] - 1\n",
+    "# customer_months = df_last_6_months.groupby(['CustomerID', 'Month']).size().reset_index(name='Purchases')\n",
+    "# customer_months['PreviousMonth'] = customer_months['Month'] - 1\n",
     "\n",
-    "customer_months.head()"
+    "# customer_months.head()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# returning_customers = customer_months.merge(\n",
+    "#     customer_months, \n",
+    "#     left_on=['CustomerID', 'Month'], \n",
+    "#     right_on=['CustomerID', 'PreviousMonth']\n",
+    "# )\n",
+    "\n",
+    "# returning_customers.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# monthly_retention = returning_customers.groupby('Month_x').agg({'CustomerID': 'nunique'}).reset_index()\n",
+    "# monthly_retention.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/var/folders/2j/ryb6v7ns2t9760z6yvvtp83m0000gn/T/ipykernel_25109/2230960188.py:16: SettingWithCopyWarning:\n",
+      "\n",
+      "\n",
+      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
+      "Try using .loc[row_indexer,col_indexer] = value instead\n",
+      "\n",
+      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
+      "\n"
+     ]
+    },
+    {
      "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>CustomerID</th>\n",
-       "      <th>Month_x</th>\n",
-       "      <th>Purchases_x</th>\n",
-       "      <th>PreviousMonth_x</th>\n",
-       "      <th>Month_y</th>\n",
-       "      <th>Purchases_y</th>\n",
-       "      <th>PreviousMonth_y</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>12362.0</td>\n",
-       "      <td>2011-07</td>\n",
-       "      <td>19</td>\n",
-       "      <td>2011-06</td>\n",
-       "      <td>2011-08</td>\n",
-       "      <td>33</td>\n",
-       "      <td>2011-07</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>12362.0</td>\n",
-       "      <td>2011-08</td>\n",
-       "      <td>33</td>\n",
-       "      <td>2011-07</td>\n",
-       "      <td>2011-09</td>\n",
-       "      <td>40</td>\n",
-       "      <td>2011-08</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>12362.0</td>\n",
-       "      <td>2011-09</td>\n",
-       "      <td>40</td>\n",
-       "      <td>2011-08</td>\n",
-       "      <td>2011-10</td>\n",
-       "      <td>75</td>\n",
-       "      <td>2011-09</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>12362.0</td>\n",
-       "      <td>2011-10</td>\n",
-       "      <td>75</td>\n",
-       "      <td>2011-09</td>\n",
-       "      <td>2011-11</td>\n",
-       "      <td>19</td>\n",
-       "      <td>2011-10</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>12362.0</td>\n",
-       "      <td>2011-11</td>\n",
-       "      <td>19</td>\n",
-       "      <td>2011-10</td>\n",
-       "      <td>2011-12</td>\n",
-       "      <td>30</td>\n",
-       "      <td>2011-11</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "   CustomerID  Month_x  Purchases_x PreviousMonth_x  Month_y  Purchases_y  \\\n",
-       "0     12362.0  2011-07           19         2011-06  2011-08           33   \n",
-       "1     12362.0  2011-08           33         2011-07  2011-09           40   \n",
-       "2     12362.0  2011-09           40         2011-08  2011-10           75   \n",
-       "3     12362.0  2011-10           75         2011-09  2011-11           19   \n",
-       "4     12362.0  2011-11           19         2011-10  2011-12           30   \n",
-       "\n",
-       "  PreviousMonth_y  \n",
-       "0         2011-07  \n",
-       "1         2011-08  \n",
-       "2         2011-09  \n",
-       "3         2011-10  \n",
-       "4         2011-11  "
-      ]
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "alignmentgroup": "True",
+         "hovertemplate": "Revenue ($)=%{x}<br>Product=%{y}<extra></extra>",
+         "legendgroup": "",
+         "marker": {
+          "color": "#636efa",
+          "pattern": {
+           "shape": ""
+          }
+         },
+         "name": "",
+         "offsetgroup": "",
+         "orientation": "h",
+         "showlegend": false,
+         "textposition": "auto",
+         "type": "bar",
+         "x": [
+          206245.48,
+          164762.19,
+          99668.47,
+          98302.98,
+          92356.03,
+          66756.59,
+          66230.64,
+          63791.94,
+          58959.729999999996,
+          53768.060000000005
+         ],
+         "xaxis": "x",
+         "y": [
+          "DOTCOM POSTAGE",
+          "REGENCY CAKESTAND 3 TIER",
+          "WHITE HANGING HEART T-LIGHT HOLDER",
+          "PARTY BUNTING",
+          "JUMBO BAG RED RETROSPOT",
+          "RABBIT NIGHT LIGHT",
+          "POSTAGE",
+          "PAPER CHAIN KIT 50'S CHRISTMAS ",
+          "ASSORTED COLOUR BIRD ORNAMENT",
+          "CHILLI LIGHTS"
+         ],
+         "yaxis": "y"
+        }
+       ],
+       "layout": {
+        "barmode": "relative",
+        "legend": {
+         "tracegroupgap": 0
+        },
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "heatmapgl": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmapgl"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "#E5ECF6",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "white"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "#E5ECF6",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "radialaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "yaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "zaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "caxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "title": {
+         "text": "Revenue by Product"
+        },
+        "xaxis": {
+         "anchor": "y",
+         "domain": [
+          0,
+          1
+         ],
+         "title": {
+          "text": "Revenue ($)"
+         }
+        },
+        "yaxis": {
+         "anchor": "x",
+         "categoryorder": "total ascending",
+         "domain": [
+          0,
+          1
+         ],
+         "title": {
+          "text": "Product"
+         }
+        }
+       }
+      }
      },
-     "execution_count": 20,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
-    "returning_customers = customer_months.merge(\n",
-    "    customer_months, \n",
-    "    left_on=['CustomerID', 'Month'], \n",
-    "    right_on=['CustomerID', 'PreviousMonth']\n",
+    "import plotly.express as px\n",
+    "\n",
+    "def get_product_revenue(df):\n",
+    "    df['Revenue'] = df['Quantity'] * df['UnitPrice']\n",
+    "    df_grouped = df.groupby('Description', as_index=False)['Revenue'].sum()\n",
+    "    df_grouped = df_grouped.sort_values(by='Revenue', ascending=False)\n",
+    "    \n",
+    "    return df_grouped\n",
+    "\n",
+    "# Get product revenue\n",
+    "product_revenue = get_product_revenue(df)\n",
+    "\n",
+    "# Select the top 10 products (already sorted)\n",
+    "top_product_revenue = product_revenue.head(10)\n",
+    "\n",
+    "top_product_revenue['Description'] = pd.Categorical(\n",
+    "    top_product_revenue['Description'], \n",
+    "    categories=top_product_revenue.sort_values('Revenue', ascending=False)['Description'], \n",
+    "    ordered=True\n",
     ")\n",
     "\n",
-    "returning_customers.head()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 21,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>Month_x</th>\n",
-       "      <th>CustomerID</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>2011-06</td>\n",
-       "      <td>322</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>2011-07</td>\n",
-       "      <td>433</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>2011-08</td>\n",
-       "      <td>465</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>2011-09</td>\n",
-       "      <td>552</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>2011-10</td>\n",
-       "      <td>690</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "   Month_x  CustomerID\n",
-       "0  2011-06         322\n",
-       "1  2011-07         433\n",
-       "2  2011-08         465\n",
-       "3  2011-09         552\n",
-       "4  2011-10         690"
-      ]
-     },
-     "execution_count": 21,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "monthly_retention = returning_customers.groupby('Month_x').agg({'CustomerID': 'nunique'}).reset_index()\n",
-    "monthly_retention.head()"
+    "# Create horizontal bar chart\n",
+    "fig = px.bar(\n",
+    "    top_product_revenue,\n",
+    "    x='Revenue',\n",
+    "    y='Description',\n",
+    "    orientation='h',\n",
+    "    title='Revenue by Product',\n",
+    "    labels={'Revenue': 'Revenue ($)', 'Description': 'Product'}\n",
+    ")\n",
+    "\n",
+    "# Ensure bars are ordered from highest to lowest\n",
+    "fig.update_layout(yaxis={'categoryorder': 'total ascending'})  # 'total ascending' for highest on top\n",
+    "\n",
+    "# Show figure\n",
+    "fig.show()\n"
    ]
   },
   {
@@ -695,7 +1261,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "563",
+   "display_name": "retailpulse",
    "language": "python",
    "name": "python3"
   },
@@ -709,7 +1275,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.0"
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,

--- a/environment.yaml
+++ b/environment.yaml
@@ -5,6 +5,7 @@ channels:
 dependencies:
   - python=3.9.12
   - dash=2.7.0
+  - altair-all=5.5.0
   - pandas=1.5.3 
   - numpy=1.23.5
   - scikit-learn=1.1.3
@@ -16,4 +17,5 @@ dependencies:
   - openpyxl
   - pip:
     - werkzeug==2.0.3
+    - dash-vega-components==0.11.0
     - dash-bootstrap-components

--- a/src/app.py
+++ b/src/app.py
@@ -1,14 +1,14 @@
 import dash
 import dash_bootstrap_components as dbc
 from dash import dcc, html
-from components.general import dashboard_title, metric_toggle, retention_slider
+from components.general import dashboard_title
 from callbacks.charts import register_callbacks
 
 from components.map_card import map_card
 from components.revenue_trends_card import revenue_trends_card
 from components.customer_retention_card import customer_retention_card
 from components.product_revenue_card import product_revenue_card
-
+from components.dhruv_card import dhruv_card
 
 # Initialize Dash app
 app = dash.Dash(__name__, external_stylesheets=[dbc.themes.BOOTSTRAP])
@@ -19,25 +19,22 @@ app.layout = dbc.Container(fluid=True, children=[
     # Title
     dashboard_title(),
 
-    # Row for Side-by-Side Charts
     dbc.Row([
-        # Map Card
-        dbc.Col(map_card(), width=6),
+        dbc.Col(product_revenue_card(), width=12)
+    ], className="mb-4"),  # Adds margin below the row
 
-        # Product Revenue Card
-        dbc.Col(product_revenue_card(), width=6)
-
-    ], className="align-items-stretch"),  # Forces equal height for both cards
-
-    # Row for Side-by-Side Charts
     dbc.Row([
-        # Revenue Trends Card
-        dbc.Col(revenue_trends_card(), width=6),
+        dbc.Col([
+            revenue_trends_card(),
+            customer_retention_card()
+        ], width=6),
 
-        # Customer Retention Card
-        dbc.Col(customer_retention_card(), width=6)
-
-    ], className="align-items-stretch")  # Forces equal height for both cards
+        # Right Column: Choropleth Map & Another Chart Stacked
+        dbc.Col([
+            map_card(),
+            dhruv_card()
+        ], width=6)
+    ], className="align-items-stretch")
 ])
 
 # Register Callbacks

--- a/src/app.py
+++ b/src/app.py
@@ -1,6 +1,5 @@
 import dash
 import dash_bootstrap_components as dbc
-from dash import dcc, html
 from components.general import dashboard_title
 from callbacks.charts import register_callbacks
 
@@ -9,9 +8,13 @@ from components.revenue_trends_card import revenue_trends_card
 from components.customer_retention_card import customer_retention_card
 from components.product_revenue_card import product_revenue_card
 from components.dhruv_card import dhruv_card
+from components.footer import footer
+from components.header import dashboard_title
+
 
 # Initialize Dash app
 app = dash.Dash(__name__, external_stylesheets=[dbc.themes.BOOTSTRAP])
+server = app.server
 
 # Layout
 app.layout = dbc.Container(fluid=True, children=[
@@ -34,7 +37,9 @@ app.layout = dbc.Container(fluid=True, children=[
             map_card(),
             dhruv_card()
         ], width=6)
-    ], className="align-items-stretch")
+    ], className="align-items-stretch"),
+
+    footer()
 ])
 
 # Register Callbacks

--- a/src/app.py
+++ b/src/app.py
@@ -1,6 +1,5 @@
 import dash
 import dash_bootstrap_components as dbc
-from components.general import dashboard_title
 from callbacks.charts import register_callbacks
 
 from components.map_card import map_card

--- a/src/app.py
+++ b/src/app.py
@@ -7,6 +7,7 @@ from callbacks.charts import register_callbacks
 from components.map_card import map_card
 from components.revenue_trends_card import revenue_trends_card
 from components.customer_retention_card import customer_retention_card
+from components.product_revenue_card import product_revenue_card
 
 
 # Initialize Dash app
@@ -18,8 +19,15 @@ app.layout = dbc.Container(fluid=True, children=[
     # Title
     dashboard_title(),
 
-    # Full-width Geographical Map in a Card
-    map_card(),
+    # Row for Side-by-Side Charts
+    dbc.Row([
+        # Map Card
+        dbc.Col(map_card(), width=6),
+
+        # Product Revenue Card
+        dbc.Col(product_revenue_card(), width=6)
+
+    ], className="align-items-stretch"),  # Forces equal height for both cards
 
     # Row for Side-by-Side Charts
     dbc.Row([

--- a/src/callbacks/charts.py
+++ b/src/callbacks/charts.py
@@ -24,7 +24,7 @@ def register_callbacks(app):
             locations='iso_alpha',
             color=metric,
             hover_name='Country',
-            title='Geographical Sales Distribution',
+            title='🌍 Geographical Sales Distribution',
             color_continuous_scale=px.colors.sequential.Viridis,
             projection='mercator',
             custom_data=['Country', 'Revenue', 'Quantity']
@@ -33,12 +33,11 @@ def register_callbacks(app):
         # Resize map
         fig.update_layout(
             autosize=False,
-            margin=dict(l=0, r=0, b=0, t=0, pad=4, autoexpand=True),
-            width=800,
+            margin=dict(l=0, r=0, b=0, t=50, pad=4, autoexpand=True),
+            width=700,
             height=400
         )
 
-        
 
         fig.update_geos(lataxis_range=[-20, 90])
 
@@ -115,7 +114,7 @@ def register_callbacks(app):
         Input('toggle-metric', 'value')
     )
     def create_revenue_by_product(metric):
-        top_product_revenue = product_revenue.sort_values(by='Revenue', ascending=False).head(10)
+        top_product_revenue = product_revenue.head(10)
         
         fig = px.bar(
             top_product_revenue,
@@ -125,5 +124,5 @@ def register_callbacks(app):
             title='Revenue by Product',
             labels={'Revenue': 'Revenue ($)', 'Description': 'Product'}
         )
-        fig.update_layout(yaxis={'categoryorder':'total descending'})
+        fig.update_layout(yaxis={'categoryorder':'total ascending'})
         return fig

--- a/src/callbacks/charts.py
+++ b/src/callbacks/charts.py
@@ -93,19 +93,27 @@ def register_callbacks(app):
         return fig
 
     @app.callback(
-        Output('revenue-trends', 'figure'),
+        Output('revenue-trends', 'spec'),
         Input('toggle-metric', 'value')
     )
+
     def create_revenue_trends(metric):
-        fig = px.line(
-            revenue_trends,
-            x='InvoiceDate',
-            y='Revenue',
+        fig = alt.Chart(revenue_trends, width='container', height='container').mark_line(point=True).encode(
+            x=alt.X('InvoiceDate:T', title='Date', axis=alt.Axis(format='%b %Y')),  # Format dates
+            y=alt.Y('Revenue:Q', title='Revenue ($)'),
+            tooltip=['InvoiceDate', 'Revenue']
+        ).properties(
             title='Monthly Revenue Trends',
-            labels={'Revenue': 'Revenue ($)', 'InvoiceDate': 'Date'}
+            width="container",
+            height="container"
+        ).configure_axis(
+            labelFontSize=16,
+            titleFontSize=20
+        ).configure_title(
+            fontSize=20
         )
-        fig.update_traces(mode='lines+markers', marker=dict(size=8, symbol='circle'))
-        return fig
+        
+        return fig.to_dict()
 
 
 

--- a/src/callbacks/charts.py
+++ b/src/callbacks/charts.py
@@ -105,11 +105,11 @@ def register_callbacks(app):
 
     @app.callback(
         Output('revenue-trends', 'spec'),
-        Input('toggle-metric', 'value')
+        Input('num-months', 'value')
     )
 
-    def create_revenue_trends(metric):
-        fig = alt.Chart(revenue_trends, width='container', height='container').mark_line(point=True).encode(
+    def create_revenue_trends(num_months):
+        fig = alt.Chart(revenue_trends.head(num_months), width='container', height='container').mark_line(point=True).encode(
             x=alt.X('InvoiceDate:T', title='Date', axis=alt.Axis(format='%b %Y')),  # Format dates
             y=alt.Y('Revenue:Q', title='Revenue ($)'),
             tooltip=['InvoiceDate', 'Revenue']
@@ -127,10 +127,9 @@ def register_callbacks(app):
 
 
     @app.callback(
-        Output('revenue-by-product', 'spec'),
-        Input('toggle-metric', 'value')
+        Output('revenue-by-product', 'spec')
     )
-    def create_revenue_by_product(metric):
+    def create_revenue_by_product():
         top_product_revenue = product_revenue.nlargest(10, 'Revenue')
     
         fig = alt.Chart(top_product_revenue, width='container', height='container').mark_bar().encode(

--- a/src/callbacks/charts.py
+++ b/src/callbacks/charts.py
@@ -1,13 +1,14 @@
 import pandas as pd
 from dash import Input, Output
 import plotly.express as px
-from data.data import get_monthly_customer_retention, get_revenue_trends, get_country_sales, get_data
+from data.data import get_monthly_customer_retention, get_revenue_trends, get_country_sales, get_data, get_product_revenue
 
 
 df = get_data()
 revenue_trends = get_revenue_trends()
 monthly_retention = get_monthly_customer_retention(6)
 country_sales = get_country_sales()
+product_revenue = get_product_revenue()
 
 
 def register_callbacks(app):
@@ -105,4 +106,24 @@ def register_callbacks(app):
             labels={'Revenue': 'Revenue ($)', 'InvoiceDate': 'Date'}
         )
         fig.update_traces(mode='lines+markers', marker=dict(size=8, symbol='circle'))
+        return fig
+
+
+
+    @app.callback(
+        Output('revenue-by-product', 'figure'),
+        Input('toggle-metric', 'value')
+    )
+    def create_revenue_by_product(metric):
+        top_product_revenue = product_revenue.sort_values(by='Revenue', ascending=False).head(10)
+        
+        fig = px.bar(
+            top_product_revenue,
+            x='Revenue',
+            y='Description',
+            orientation='h',
+            title='Revenue by Product',
+            labels={'Revenue': 'Revenue ($)', 'Description': 'Product'}
+        )
+        fig.update_layout(yaxis={'categoryorder':'total descending'})
         return fig

--- a/src/callbacks/charts.py
+++ b/src/callbacks/charts.py
@@ -127,9 +127,10 @@ def register_callbacks(app):
 
 
     @app.callback(
-        Output('revenue-by-product', 'spec')
+        Output('revenue-by-product', 'spec'),
+        Input('toggle-metric', 'value')
     )
-    def create_revenue_by_product():
+    def create_revenue_by_product(metric):
         top_product_revenue = product_revenue.nlargest(10, 'Revenue')
     
         fig = alt.Chart(top_product_revenue, width='container', height='container').mark_bar().encode(

--- a/src/components/customer_retention_card.py
+++ b/src/components/customer_retention_card.py
@@ -1,13 +1,14 @@
 import dash_bootstrap_components as dbc
-from dash import dcc
+from dash import dcc, html
 
 from components.general import retention_slider
+import dash_vega_components as dvc
 
 def customer_retention_card():
     return dbc.Card(
         dbc.CardBody([
-            dcc.Graph(id='monthly-retention', style={'height': '100%', 'width': '100%'}),
-            retention_slider()
+            dvc.Vega(id='monthly-retention', spec={}, style={'height': '100%', 'width': '100%', 'flex': '1'}),
+            html.Div(retention_slider(), style={'margin-top': 'auto', 'height': '15%'})
         ], style={'display': 'flex', 'flex-direction': 'column', 'height': '100%', 'overflow': 'hidden'}), 
         className="mb-4 shadow",
         style={'display': 'flex', 'flex-direction': 'column', 'height': '60vh', 'min-height': '400px'}

--- a/src/components/customer_retention_card.py
+++ b/src/components/customer_retention_card.py
@@ -9,6 +9,6 @@ def customer_retention_card():
             dcc.Graph(id='monthly-retention', style={'height': '100%', 'width': '100%'}),
             retention_slider()
         ], style={'display': 'flex', 'flex-direction': 'column', 'height': '100%', 'overflow': 'hidden'}), 
-        className="shadow",
-        style={'display': 'flex', 'flex-direction': 'column', 'height': '48vh', 'min-height': '400px'}
+        className="mb-4 shadow",
+        style={'display': 'flex', 'flex-direction': 'column', 'height': '60vh', 'min-height': '400px'}
     )

--- a/src/components/dhruv_card.py
+++ b/src/components/dhruv_card.py
@@ -5,7 +5,7 @@ import dash_vega_components as dvc
 def dhruv_card():
     return dbc.Card(
         dbc.CardBody([
-            dvc.Vega(id='revenue-by-product', spec={}, style={'height': '100%', 'width': '100%', 'flex': '1'})
+            dvc.Vega(id='xxxx', spec={}, style={'height': '100%', 'width': '100%', 'flex': '1'})
         ], style={'display': 'flex', 'flex-direction': 'column', 'height': '100%', 'overflow': 'hidden'}), 
         className="mb-4 shadow",
         style={'display': 'flex', 'flex-direction': 'column', 'height': '60vh', 'min-height': '400px'}

--- a/src/components/dhruv_card.py
+++ b/src/components/dhruv_card.py
@@ -1,0 +1,11 @@
+import dash_bootstrap_components as dbc
+from dash import dcc
+
+def dhruv_card():
+    return dbc.Card(
+        dbc.CardBody([
+            dcc.Graph(id='xxx', style={'height': '100%', 'width': '100%'})
+        ], style={'display': 'flex', 'flex-direction': 'column', 'height': '100%', 'overflow': 'hidden'}), 
+        className="mb-4 shadow",
+        style={'display': 'flex', 'flex-direction': 'column', 'height': '60vh', 'min-height': '400px'}
+    )

--- a/src/components/dhruv_card.py
+++ b/src/components/dhruv_card.py
@@ -1,10 +1,11 @@
 import dash_bootstrap_components as dbc
 from dash import dcc
+import dash_vega_components as dvc
 
 def dhruv_card():
     return dbc.Card(
         dbc.CardBody([
-            dcc.Graph(id='xxx', style={'height': '100%', 'width': '100%'})
+            dvc.Vega(id='revenue-by-product', spec={}, style={'height': '100%', 'width': '100%', 'flex': '1'})
         ], style={'display': 'flex', 'flex-direction': 'column', 'height': '100%', 'overflow': 'hidden'}), 
         className="mb-4 shadow",
         style={'display': 'flex', 'flex-direction': 'column', 'height': '60vh', 'min-height': '400px'}

--- a/src/components/footer.py
+++ b/src/components/footer.py
@@ -1,0 +1,26 @@
+import dash_bootstrap_components as dbc
+from dash import html
+
+def footer():
+    return dbc.Container(
+        dbc.Row(
+            dbc.Col(
+                html.P([
+                    "© 2025 RetailPulse Dashboard | Built with Dash & Plotly",
+                    html.Br(),
+                    "Developed by: Dhruv, Farhan, Gilbert, & Jam"
+                ],
+                className="text-center",
+                style={
+                    "padding": "5px",
+                    "fontSize": "1 vw",
+                    "color": "white",
+                    "textAlign": "center",
+                    "backgroundColor": "#007BFF"
+                }),
+                width=12
+            )
+        ),
+        fluid=True,
+        className="footer"
+    )

--- a/src/components/general.py
+++ b/src/components/general.py
@@ -11,8 +11,8 @@ def metric_toggle():
         dbc.Col(dcc.RadioItems(
             id='toggle-metric', 
             options=[
-                {'label': 'Quantity', 'value': 'Quantity'},
-                {'label': 'Revenue', 'value': 'Revenue'}
+                {'label': html.Span("Quantity", style={'marginRight': '15px'}), 'value': 'Quantity'},
+                {'label': html.Span("Revenue", style={'marginRight': '15px'}), 'value': 'Revenue'}
             ],
             value='Quantity',
             inline=True,

--- a/src/components/general.py
+++ b/src/components/general.py
@@ -1,10 +1,6 @@
 from dash import dcc, html
 import dash_bootstrap_components as dbc
 
-# Sales dashboard title
-def dashboard_title():
-    return html.H1("Retail Pulse", className="text-center text-primary")
-
 # Metric toggle radio buttons
 def metric_toggle():
     return dbc.Row([
@@ -23,8 +19,7 @@ def metric_toggle():
 # Monthly retention slider
 def retention_slider():
     return dbc.Col([
-            html.Label("# months:"),
-            dcc.Slider(id='num-months', min=1, max=12, step=1, value=6, 
+        html.H5("# Months"),
+        dcc.Slider(id='num-months', min=1, max=12, step=1, value=6, 
                        marks={i: str(i) for i in range(1, 13)})
-      
     ], className="m-1")

--- a/src/components/header.py
+++ b/src/components/header.py
@@ -1,0 +1,25 @@
+import dash_bootstrap_components as dbc
+from dash import html
+
+
+def dashboard_title():
+    return dbc.Container(
+        dbc.Row(
+            dbc.Col(
+                html.H1(
+                    "Retail Pulse",
+                    className="text-center",
+                    style={
+                        "padding": "2vh 0",
+                        "fontSize": "3vw",  
+                        "color": "white",
+                        "textAlign": "center",
+                        "backgroundColor": "#007BFF"
+                    }
+                ),
+                width=12
+            )
+        ),
+        fluid=True,
+        className="header"
+    )

--- a/src/components/map_card.py
+++ b/src/components/map_card.py
@@ -7,7 +7,8 @@ def map_card():
     return dbc.Card(
         dbc.CardBody([
             metric_toggle(),
-            dcc.Graph(id='map', style={'height': '50vh', 'width': '75vh'}) 
+            dcc.Graph(id='map', style={'height': '50vh', 'width': '20vw'}) 
         ]),
-        className="mb-4 shadow"
+        className="mb-4 shadow",
+        style={'display': 'flex', 'flex-direction': 'column', 'height': '60vh', 'min-height': '400px'}
     )

--- a/src/components/product_revenue_card.py
+++ b/src/components/product_revenue_card.py
@@ -1,0 +1,11 @@
+import dash_bootstrap_components as dbc
+from dash import dcc
+
+def product_revenue_card():
+    return dbc.Card(
+        dbc.CardBody([
+            dcc.Graph(id='revenue-by-product', style={'height': '100%', 'width': '100%'})
+        ], style={'display': 'flex', 'flex-direction': 'column', 'height': '100%', 'overflow': 'hidden'}), 
+        className="shadow",
+        style={'display': 'flex', 'flex-direction': 'column', 'height': '48vh', 'min-height': '400px'}
+    )

--- a/src/components/product_revenue_card.py
+++ b/src/components/product_revenue_card.py
@@ -6,6 +6,6 @@ def product_revenue_card():
         dbc.CardBody([
             dcc.Graph(id='revenue-by-product', style={'height': '100%', 'width': '100%'})
         ], style={'display': 'flex', 'flex-direction': 'column', 'height': '100%', 'overflow': 'hidden'}), 
-        className="shadow",
-        style={'display': 'flex', 'flex-direction': 'column', 'height': '48vh', 'min-height': '400px'}
+        className="mb-4 shadow",
+        style={'display': 'flex', 'flex-direction': 'column', 'height': '60vh', 'min-height': '400px'}
     )

--- a/src/components/product_revenue_card.py
+++ b/src/components/product_revenue_card.py
@@ -1,10 +1,11 @@
 import dash_bootstrap_components as dbc
 from dash import dcc
+import dash_vega_components as dvc
 
 def product_revenue_card():
     return dbc.Card(
         dbc.CardBody([
-            dcc.Graph(id='revenue-by-product', style={'height': '100%', 'width': '100%'})
+            dvc.Vega(id='revenue-by-product', spec={}, style={'height': '100%', 'width': '100%', 'flex': '1'})
         ], style={'display': 'flex', 'flex-direction': 'column', 'height': '100%', 'overflow': 'hidden'}), 
         className="mb-4 shadow",
         style={'display': 'flex', 'flex-direction': 'column', 'height': '60vh', 'min-height': '400px'}

--- a/src/components/revenue_trends_card.py
+++ b/src/components/revenue_trends_card.py
@@ -1,10 +1,11 @@
 import dash_bootstrap_components as dbc
 from dash import dcc
+import dash_vega_components as dvc
 
 def revenue_trends_card():
     return dbc.Card(
         dbc.CardBody([
-            dcc.Graph(id='revenue-trends', style={'height': '100%', 'width': '100%'}) 
+            dvc.Vega(id='revenue-trends', spec={}, style={'height': '100%', 'width': '100%', 'flex': '1'})
         ], style={'height': '100%', 'overflow': 'hidden'}),
         className="mb-4 shadow",
         style={'display': 'flex', 'flex-direction': 'column', 'height': '60vh', 'min-height': '400px'}

--- a/src/components/revenue_trends_card.py
+++ b/src/components/revenue_trends_card.py
@@ -6,5 +6,6 @@ def revenue_trends_card():
         dbc.CardBody([
             dcc.Graph(id='revenue-trends', style={'height': '100%', 'width': '100%'}) 
         ], style={'height': '100%', 'overflow': 'hidden'}),
-        style={'display': 'flex', 'flex-direction': 'column', 'height': '48vh', 'min-height': '400px'}
+        className="mb-4 shadow",
+        style={'display': 'flex', 'flex-direction': 'column', 'height': '60vh', 'min-height': '400px'}
     )

--- a/src/data/data.py
+++ b/src/data/data.py
@@ -52,3 +52,10 @@ def get_monthly_customer_retention(no_months):
     monthly_retention.rename(columns={'Month_current': 'Month'}, inplace=True)
 
     return monthly_retention
+
+def get_product_revenue():
+    df['Revenue'] = df['Quantity'] * df['UnitPrice']
+    # Group by product and sum the revenue
+    df_grouped = df.groupby('Description', as_index=False)['Revenue'].sum()
+    df_grouped = df_grouped.sort_values(by='Revenue', ascending=False)
+    return df_grouped


### PR DESCRIPTION
- [x] Add product by revenue horizontal bar chart
- [x] Add header component
- [x] Add footer component
- [x] Fix overall layout and add server variable to App.py
- [x] Standardize height and width of all cards
- [x] Add placeholder component for Dhruv
- [x] Convert all charts to altair
- [x] Connect slider to monthly revenue chart as well
- [x] Update environment.yaml to include altair and dash-vega-components